### PR TITLE
Added the ability to move map by a mouse drag

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -13,6 +13,10 @@ function love.draw()
   scene_manager:draw_scene()
 end
 
+function love.update(dt)
+  scene_manager:update_scene(dt)
+end
+
 function love.mousereleased(x, y, button)
   scene_manager:process_mouse_release(x, y, button)
 end

--- a/src/scenes/map_scene.lua
+++ b/src/scenes/map_scene.lua
@@ -18,6 +18,10 @@ function map_scene:initialize(manager)
   self.x_right = 0
   self.y_right = 0
   self.right_button_clicked = false
+
+  self.x_middle = 0
+  self.y_middle = 0
+  self.middle_button_clicked = false
 end
 
 function map_scene:set_map(map)
@@ -39,6 +43,14 @@ function map_scene:draw()
   self.camera:unset()
 end
 
+function map_scene:update(dt)
+  local x, y = love.mouse.getPosition()
+  if love.mouse.isDown("m") then
+    local sensitivity_ignore = 15
+    self.camera:move((x - self.x_middle)/-sensitivity_ignore, (y - self.y_middle)/-sensitivity_ignore)
+  end
+end
+
 function map_scene:process_mouse_release(x, y, button)
   -- convert our click to world coordinates and calculate tile index
   wx, wy = self.camera:cursorToWorld(x, y)
@@ -55,6 +67,8 @@ function map_scene:process_mouse_release(x, y, button)
     end
     x_right, y_right = self.map:getTileCenterFromIndex(row, col)
     right_button_clicked = true
+  elseif button == 'm' then
+    self.middle_button_clicked = false
   end
 end
 
@@ -73,6 +87,12 @@ function map_scene:process_mouse_press(x, y, button)
     self.camera:scale(scale)
     x_w2, y_w2 = self.camera:cursorToWorld(x, y)
     self.camera:move(x_w1 - x_w2, y_w1 - y_w2)
+  end
+
+  if button == "m" then
+    self.middle_button_clicked = true
+    self.x_middle = x
+    self.y_middle = y
   end
 end
 

--- a/src/scenes/scene_manager.lua
+++ b/src/scenes/scene_manager.lua
@@ -61,6 +61,15 @@ function scene_manager:draw_scene()
   end
 end
 
+-- Update current scene set by set_scene()
+function scene_manager:update_scene(dt)
+  if self.current_scene_object ~= nil then
+    self.current_scene_object:update(dt)
+  else
+    print('Error: No scene set! Set a scene using set_scene(identifier).')
+  end
+end
+
 function scene_manager:process_mouse_release(x, y, button)
   -- Just pass it onto the scene for now
   self.current_scene_object:process_mouse_release(x, y, button)

--- a/src/scenes/title_scene.lua
+++ b/src/scenes/title_scene.lua
@@ -29,6 +29,10 @@ function title_scene:draw()
   end
 end
 
+function title_scene:update(dt)
+
+end
+
 function title_scene:draw_title()
   width, height = love.graphics.getDimensions()
   love.graphics.setBackgroundColor(0, 0, 70)


### PR DESCRIPTION
It's not exactly the most wonderful, but a working ability to drag the map. Much easier than doing it by arrows. In order to implement this feature an update method must have been added to the scenes (and `love.update(dt)` have had to be implemented)
